### PR TITLE
Imports need to be explicit

### DIFF
--- a/R/dryadFileDownload.R
+++ b/R/dryadFileDownload.R
@@ -15,7 +15,7 @@
 #' #' @export
 #'
 dryadFileDownload <- function(doi, path="~/Downloads", name="data"){
-  encoded_doi <- str_replace_all(doi, c("https://doi.org/" = "doi%253A", "/" = "%2F"))
+  encoded_doi <- stringr::str_replace_all(doi, c("https://doi.org/" = "doi%253A", "/" = "%2F"))
   response <- GET(paste("https://datadryad.org/api/v2/datasets/",encoded_doi,"/versions?page=1&per_page=100", sep=""))
   text <- content(response, as = "text", encoding = "UTF-8")
   data <- fromJSON(text, flatten=TRUE)

--- a/R/dryadFileDownload.R
+++ b/R/dryadFileDownload.R
@@ -11,7 +11,8 @@
 #' @seealso [dryadFileDownloadID()]
 #' @examples
 #' dryadFileDownload(https://doi.org/10.5061/dryad.z08kprrk1)
-#' @export
+#' @importFrom stringr str_replace_all
+#' #' @export
 #'
 dryadFileDownload <- function(doi, path="~/Downloads", name="data"){
   encoded_doi <- str_replace_all(doi, c("https://doi.org/" = "doi%253A", "/" = "%2F"))

--- a/R/dryadFileRead.R
+++ b/R/dryadFileRead.R
@@ -12,7 +12,7 @@
 #' #' @export
 #'
 dryadFileRead <- function(doi){
-  encoded_doi <- str_replace_all(doi, c("https://doi.org/" = "doi%253A", "/" = "%2F"))
+  encoded_doi <- stringr::str_replace_all(doi, c("https://doi.org/" = "doi%253A", "/" = "%2F"))
   response <- GET(paste("https://datadryad.org/api/v2/datasets/",encoded_doi,"/versions?page=1&per_page=100", sep=""))
   text <- content(response, as = "text", encoding = "UTF-8")
   data <- fromJSON(text, flatten=TRUE)

--- a/R/dryadFileRead.R
+++ b/R/dryadFileRead.R
@@ -8,7 +8,8 @@
 #' @seealso [dryadFileReadID()]
 #' @examples
 #' dryadFileRead(https://doi.org/10.5061/dryad.z08kprrk1)
-#' @export
+#' @importFrom stringr str_replace_all
+#' #' @export
 #'
 dryadFileRead <- function(doi){
   encoded_doi <- str_replace_all(doi, c("https://doi.org/" = "doi%253A", "/" = "%2F"))

--- a/R/dryadVersionCount.R
+++ b/R/dryadVersionCount.R
@@ -9,7 +9,7 @@
 #' @importFrom stringr str_replace_all
 #' #' @export
 dryad_version_count <- function(doi){
-  encoded_doi <- str_replace_all(doi, c("https://doi.org/" = "doi%253A", "/" = "%2F"))
+  encoded_doi <- stringr::str_replace_all(doi, c("https://doi.org/" = "doi%253A", "/" = "%2F"))
   response <- GET(paste("https://datadryad.org/api/v2/datasets/",encoded_doi,"/versions?page=1&per_page=100", sep=""))
   text <- content(response, as = "text", encoding = "UTF-8")
   data <- fromJSON(text, flatten=TRUE)

--- a/R/dryadVersionCount.R
+++ b/R/dryadVersionCount.R
@@ -6,7 +6,8 @@
 #' @seealso [dryad_version_overview()]
 #' @examples
 #' dryad_version_count(https://doi.org/10.5061/dryad.z08kprrk1)
-#' @export
+#' @importFrom stringr str_replace_all
+#' #' @export
 dryad_version_count <- function(doi){
   encoded_doi <- str_replace_all(doi, c("https://doi.org/" = "doi%253A", "/" = "%2F"))
   response <- GET(paste("https://datadryad.org/api/v2/datasets/",encoded_doi,"/versions?page=1&per_page=100", sep=""))

--- a/R/dryadVersionDownload.R
+++ b/R/dryadVersionDownload.R
@@ -14,7 +14,7 @@
 #' #' @export
 #'
 dryadVersionDownload <- function(doi, path="~/Downloads"){
-  encoded_doi <- str_replace_all(doi, c("https://doi.org/" = "doi%253A", "/" = "%2F"))
+  encoded_doi <- stringr::str_replace_all(doi, c("https://doi.org/" = "doi%253A", "/" = "%2F"))
   response <- GET(paste("https://datadryad.org/api/v2/datasets/",encoded_doi,"/versions?page=1&per_page=100", sep=""))
   text <- content(response, as = "text", encoding = "UTF-8")
   data <- fromJSON(text, flatten=TRUE)

--- a/R/dryadVersionDownload.R
+++ b/R/dryadVersionDownload.R
@@ -10,7 +10,8 @@
 #' @seealso [dryadFileDownloadID()]
 #' @examples
 #' dryadVersionDownload(https://doi.org/10.5061/dryad.z08kprrk1)
-#' @export
+#' @importFrom stringr str_replace_all
+#' #' @export
 #'
 dryadVersionDownload <- function(doi, path="~/Downloads"){
   encoded_doi <- str_replace_all(doi, c("https://doi.org/" = "doi%253A", "/" = "%2F"))

--- a/R/dryadVersionInformation.R
+++ b/R/dryadVersionInformation.R
@@ -13,7 +13,7 @@
 #' @importFrom stringr str_replace_all
 #' #' @export
 dryadVersionInformation <- function(doi,...){
-  encoded_doi <- str_replace_all(doi, c("https://doi.org/" = "doi%253A", "/" = "%2F"))
+  encoded_doi <- stringr::str_replace_all(doi, c("https://doi.org/" = "doi%253A", "/" = "%2F"))
   response <- GET(paste("https://datadryad.org/api/v2/datasets/",encoded_doi,"/versions?page=1&per_page=100", sep=""))
   text <- content(response, as = "text", encoding = "UTF-8")
   data <- fromJSON(text, flatten=TRUE)

--- a/R/dryadVersionInformation.R
+++ b/R/dryadVersionInformation.R
@@ -10,7 +10,8 @@
 #' @examples
 #' dryadVersionInformation(https://doi.org/10.5061/dryad.z08kprrk1)
 #' #Use ... to pass additional arguments to dryad_version_overview().
-#' @export
+#' @importFrom stringr str_replace_all
+#' #' @export
 dryadVersionInformation <- function(doi,...){
   encoded_doi <- str_replace_all(doi, c("https://doi.org/" = "doi%253A", "/" = "%2F"))
   response <- GET(paste("https://datadryad.org/api/v2/datasets/",encoded_doi,"/versions?page=1&per_page=100", sep=""))


### PR DESCRIPTION
The Roxygen importFrom can be in one place, but the stringr::str_replace_all needs to be everywhere.  Similar for other functions you are using for other packages.